### PR TITLE
Tap button instead of image

### DIFF
--- a/BMM.Tests/BMM.UITests/Views/AlbumPage.cs
+++ b/BMM.Tests/BMM.UITests/Views/AlbumPage.cs
@@ -27,7 +27,7 @@ namespace BMM.UITests.Views
         {
             get
             {
-                return c => c.Marked("icon_options");
+                return c => c.Marked("icon options");
             }
         }
 
@@ -111,7 +111,7 @@ namespace BMM.UITests.Views
         {
             get
             {
-                return c => c.Marked("icon_options");
+                return c => c.Marked("icon options");
             }
         }
     }

--- a/BMM.Tests/BMM.UITests/Views/NavigationBar.cs
+++ b/BMM.Tests/BMM.UITests/Views/NavigationBar.cs
@@ -68,7 +68,7 @@ namespace BMM.UITests.Views
         {
             get
             {
-                return c => c.Marked("icon_options");
+                return c => c.Marked("icon options");
             }
         }
 


### PR DESCRIPTION
Appcenter seems to have problems on tapping the images so instead we use the buttons now.