### PR TITLE
Just provide the url scheme for the redirect url

### DIFF
--- a/BMM.UI.iOS/Application/Implementations/Oidc/SafariAuthenticationSessionBrowser.cs
+++ b/BMM.UI.iOS/Application/Implementations/Oidc/SafariAuthenticationSessionBrowser.cs
@@ -15,8 +15,8 @@ namespace BMM.UI.iOS.Implementations
             var wait = new TaskCompletionSource<BrowserResult>();
 
             _authenticationSession = new SFAuthenticationSession(
-                new NSUrl(options.StartUrl),
-                options.EndUrl,
+                NSUrl.FromString(options.StartUrl),
+                NSUrl.FromString(options.EndUrl).Scheme,
                 (callbackUrl, error) =>
                 {
                     if (error != null)

--- a/BMM.UI.iOS/Application/Implementations/Oidc/WebAuthenticationSessionBrowser.cs
+++ b/BMM.UI.iOS/Application/Implementations/Oidc/WebAuthenticationSessionBrowser.cs
@@ -16,8 +16,8 @@ namespace BMM.UI.iOS.Implementations
             var wait = new TaskCompletionSource<BrowserResult>();
 
             _authenticationSession = new ASWebAuthenticationSession(
-                new NSUrl(options.StartUrl),
-                options.EndUrl,
+                NSUrl.FromString(options.StartUrl),
+                NSUrl.FromString(options.EndUrl).Scheme,
                 (callbackUrl, error) =>
                 {
                     if (error != null)


### PR DESCRIPTION
There is a assumptions that iOS just takes the first custom url scheme if nothing is defined but it's nowhere documented. So defining it explicitly seems less confusing and more robust.