### PR TITLE
15 seconds jumping on Android fixed

### DIFF
--- a/BMM.UI.Android/Application/NewMediaPlayer/Notification/CustomAction.cs
+++ b/BMM.UI.Android/Application/NewMediaPlayer/Notification/CustomAction.cs
@@ -20,7 +20,13 @@ namespace BMM.UI.Droid.Application.NewMediaPlayer.Notification
 
         public PendingIntent GetIntent(Context context)
         {
-            return PendingIntent.GetBroadcast(context, 100, new Intent(_action).SetPackage(context.PackageName), PendingIntentFlags.CancelCurrent);
+            var intent = new Intent(_action);
+            intent.SetPackage(context.PackageName);
+
+            ComponentName componentName = new ComponentName(context, Java.Lang.Class.FromType(typeof(CustomActionBroadcastReceiver)));
+            intent.SetComponent(componentName);
+
+            return PendingIntent.GetBroadcast(context, 100, intent, 0);
         }
     }
 }

--- a/BMM.UI.Android/Application/NewMediaPlayer/Notification/MusicServiceMediaCallback.cs
+++ b/BMM.UI.Android/Application/NewMediaPlayer/Notification/MusicServiceMediaCallback.cs
@@ -6,12 +6,18 @@ namespace BMM.UI.Droid.Application.NewMediaPlayer.Notification
 {
     public class MusicServiceMediaCallback : MediaControllerCompat.Callback
     {
+        private int? _previousState;
+
         public Action<PlaybackStateCompat> OnPlaybackStateChangedImpl { private get; set; }
         public Action<MediaMetadataCompat> OnMetadataChangedImpl { private get; set; }
         public Action OnSessionDestroyedImpl { get; set; }
 
         public override void OnPlaybackStateChanged(PlaybackStateCompat state)
         {
+            if (_previousState == state.State)
+                return;
+
+            _previousState = state.State;
             OnPlaybackStateChangedImpl?.Invoke(state);
         }
 


### PR DESCRIPTION
Starting from Android O we need to use explicit Intents (with ComponentName set) to have possibility of intercept them in  Broadcast Receivers.

As additional buttons in Media Player ("Skip Backward" and "Skip Forward") were using this mechanism,  some adjustments were needed.
