### PR TITLE
AssertContentLanguageChanged UI Test fix

### DIFF
--- a/BMM.Core/ViewModels/Base/DocumentsViewModel.cs
+++ b/BMM.Core/ViewModels/Base/DocumentsViewModel.cs
@@ -352,28 +352,11 @@ namespace BMM.Core.ViewModels.Base
             if (documents == null)
                 return;
 
-            var docList = documents.ToList();
-
-            if (!HasDocumentListChanged(docList))
-                return;
-
             MvxMainThreadAsyncDispatcher.ExecuteOnMainThreadAsync(() =>
             {
-                Documents.ReplaceWith(docList);
+                Documents.ReplaceWith(documents);
                 RaisePropertyChanged(() => TrackCountString);
             });
-        }
-
-        private bool HasDocumentListChanged(IList<Document> newList)
-        {
-            var allIDs = Documents
-                .Select(x => x.Id)
-                .ToList();
-
-            if (Documents.Count == newList.Count && newList.All(x => allIDs.Contains(x.Id)))
-                return false;
-
-            return true;
         }
 
         protected override async Task DocumentAction(Document item, IList<Track> list)


### PR DESCRIPTION
During fixing one bug I added simple check if newly loaded documents list is the same as already loaded (to improve performance).
The check was basing on documents count and ID of elements, but I didn't took into account language changing, when elements have the same count and IDs, but different other properties.
I am reverting this change. 

If we want to have this check in the future we need to introduce some more advanced equality comparer. One of the soultion is overriding Equals in every document, which may have properties changed by language changed, like Title, Cover, Author Name etc.

PS. This issue has been found by UI Test :)