### PR TITLE
provide additional information in PlaybackOrigin

### DIFF
--- a/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
+++ b/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
@@ -80,6 +80,7 @@ namespace BMM.Core.Implementations.DeepLinking
                 new RegexDeepLink("^/music$", NavigateTo<ExploreRecentMusicViewModel>),
                 new RegexDeepLink("^/contributors$", NavigateTo<ExploreContributorsViewModel>),
                 new RegexDeepLink("^/featured$", NavigateTo<CuratedPlaylistsViewModel>),
+                new RegexDeepLink("^/archive", NavigateTo<LibraryArchiveViewModel>),
                 new RegexDeepLink<IdAndNameParameters>("^/playlist/curated/(?<id>[0-9]+)(/(?<name>.*))?$", OpenCuratedPlaylist),
                 new RegexDeepLink<IdAndNameParameters>("^/playlist/private/(?<id>[0-9]+)(/(?<name>.*))?$", OpenTrackCollection),
                 new RegexDeepLink<IdAndNameParameters>("^/playlist/podcast/(?<id>[0-9]+)(/(?<name>.*))?$", OpenPodcast),

--- a/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
+++ b/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
@@ -179,7 +179,9 @@ namespace BMM.Core.Implementations.DeepLinking
                 return false;
 
             if (shouldLogEvent)
-                _analytics.LogEvent("deep link opened", new Dictionary<string, object> {{"uri", uri.AbsolutePath}});
+                _analytics.LogEvent("deep link opened", new Dictionary<string, object> { { "uri", uri.AbsolutePath } });
+            else
+                _analytics.LogEvent("internal link opened", new Dictionary<string, object> { { "uri", uri.AbsolutePath } });
 
             foreach (var link in _links)
             {

--- a/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
+++ b/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
@@ -169,19 +169,16 @@ namespace BMM.Core.Implementations.DeepLinking
             await PlayTracks(new[] { requestedTrack }, PlaybackOriginName, trackLinkParameters.StartTimeInMs);
         }
 
-        public bool OpenFromInsideOfApp(Uri uri) => Open(uri, false);
+        public bool OpenFromInsideOfApp(Uri uri) => Open(uri, "internal link opened");
 
-        public bool OpenFromOutsideOfApp(Uri uri) => Open(uri, true);
+        public bool OpenFromOutsideOfApp(Uri uri) => Open(uri, "deep link opened");
 
-        private bool Open(Uri uri, bool shouldLogEvent)
+        private bool Open(Uri uri, string analyticsEventName)
         {
             if (!IsBmmUrl(uri))
                 return false;
 
-            if (shouldLogEvent)
-                _analytics.LogEvent("deep link opened", new Dictionary<string, object> { { "uri", uri.AbsolutePath } });
-            else
-                _analytics.LogEvent("internal link opened", new Dictionary<string, object> { { "uri", uri.AbsolutePath } });
+            _analytics.LogEvent(analyticsEventName, new Dictionary<string, object> { { "uri", uri.AbsolutePath } });
 
             foreach (var link in _links)
             {

--- a/BMM.Core/ViewModels/AlbumViewModel.cs
+++ b/BMM.Core/ViewModels/AlbumViewModel.cs
@@ -10,7 +10,6 @@ using BMM.Core.Helpers;
 using BMM.Core.Implementations.TrackInformation.Strategies;
 using BMM.Core.Translation;
 using MvvmCross.Commands;
-using MvvmCross.Localization;
 using MvvmCross.ViewModels;
 
 namespace BMM.Core.ViewModels
@@ -38,6 +37,11 @@ namespace BMM.Core.ViewModels
                 RaisePropertyChanged(() => Image);
                 RaisePropertyChanged(() => ShowImage);
             }
+        }
+
+        public override IEnumerable<string> PlaybackOrigin()
+        {
+            return new[] { Album.Id.ToString() };
         }
 
         public AlbumViewModel(IShareLink shareLink)

--- a/BMM.Core/ViewModels/AslaksenTeaserViewModel.cs
+++ b/BMM.Core/ViewModels/AslaksenTeaserViewModel.cs
@@ -63,7 +63,7 @@ namespace BMM.Core.ViewModels
                 var randomIndex = _random.Next(docs.Count);
                 var randomTrack = docs[randomIndex];
 
-                await _mediaPlayer.Play(new List<IMediaTrack> {randomTrack}, randomTrack, GetType().Name);
+                await _mediaPlayer.Play(new List<IMediaTrack> {randomTrack}, randomTrack, PlaybackOriginString);
 
                 _analytics.LogEvent("Aslaksen play random command was used");
 
@@ -81,7 +81,7 @@ namespace BMM.Core.ViewModels
                 if (filteredDocs.Any())
                     docs = filteredDocs;
 
-                await _mediaPlayer.Play(docs, docs.First(), GetType().Name);
+                await _mediaPlayer.Play(docs, docs.First(), PlaybackOriginString);
 
                 _analytics.LogEvent("Aslaksen play newest command was used");
             });

--- a/BMM.Core/ViewModels/Base/BaseViewModel.cs
+++ b/BMM.Core/ViewModels/Base/BaseViewModel.cs
@@ -64,6 +64,13 @@ namespace BMM.Core.ViewModels.Base
             set => SetProperty(ref _isLoading, value);
         }
 
+        public virtual string PlaybackOriginString => string.Join("|", new List<string> { GetType().Name }.Concat(PlaybackOrigin()));
+
+        public virtual IEnumerable<string> PlaybackOrigin()
+        {
+            return new List<string>();
+        }
+
         private IMvxAsyncCommand<Document> _optionsCommand;
 
         public IMvxAsyncCommand<Document> OptionCommand
@@ -184,7 +191,7 @@ namespace BMM.Core.ViewModels.Base
                             actionSheet.AddHandled(TextSource[Translations.UserDialogs_Track_QueueToPlayNext],
                                 async () =>
                                 {
-                                    var success = await mediaPlayer.QueueToPlayNext(track, GetType().Name);
+                                    var success = await mediaPlayer.QueueToPlayNext(track, PlaybackOriginString);
                                     if (success)
                                     {
                                         await Mvx.IoCProvider.Resolve<IToastDisplayer>().Success(TextSource.GetText(Translations.UserDialogs_Track_AddedToQueue, track.Title));
@@ -202,7 +209,7 @@ namespace BMM.Core.ViewModels.Base
                         actionSheet.AddHandled(TextSource[Translations.UserDialogs_Track_AddToQueue],
                             async () =>
                             {
-                                var success = await mediaPlayer.AddToEndOfQueue(track, GetType().Name);
+                                var success = await mediaPlayer.AddToEndOfQueue(track, PlaybackOriginString);
                                 if (success)
                                 {
                                     await Mvx.IoCProvider.Resolve<IToastDisplayer>().Success(TextSource.GetText(Translations.UserDialogs_Track_AddedToQueue, track.Title));
@@ -440,7 +447,7 @@ namespace BMM.Core.ViewModels.Base
         {
             if (track == null)
             {
-                Mvx.IoCProvider.Resolve<IAnalytics>().LogEvent("4934 the track is null", new Dictionary<string, object> { { "CallingType", this.GetType().FullName } });
+                Mvx.IoCProvider.Resolve<IAnalytics>().LogEvent("4934 the track is null", new Dictionary<string, object> { { "CallingType", GetType().FullName } });
                 return;
             }
 
@@ -481,7 +488,7 @@ namespace BMM.Core.ViewModels.Base
                         list.Add(track);
                     }
 
-                    await mediaPlayer.Play(list.OfType<IMediaTrack>().ToList(), track, GetType().Name);
+                    await mediaPlayer.Play(list.OfType<IMediaTrack>().ToList(), track, PlaybackOriginString);
                     break;
 
                 case DocumentType.Album:

--- a/BMM.Core/ViewModels/Base/DocumentsViewModel.cs
+++ b/BMM.Core/ViewModels/Base/DocumentsViewModel.cs
@@ -127,7 +127,7 @@ namespace BMM.Core.ViewModels.Base
 
                 if (tracks.Any())
                 {
-                    await mediaPlayer.Play(tracks, tracks.First(), GetType().Name);
+                    await mediaPlayer.Play(tracks, tracks.First(), PlaybackOriginString);
                 }
             });
 
@@ -138,7 +138,7 @@ namespace BMM.Core.ViewModels.Base
 
                 if (tracks.Any())
                 {
-                    await mediaPlayer.ShuffleList(tracks, GetType().Name);
+                    await mediaPlayer.ShuffleList(tracks, PlaybackOriginString);
                 }
             });
 

--- a/BMM.Core/ViewModels/CuratedPlaylistViewModel.cs
+++ b/BMM.Core/ViewModels/CuratedPlaylistViewModel.cs
@@ -41,6 +41,11 @@ namespace BMM.Core.ViewModels
 
         public override string Description => CuratedPlaylist.Description;
 
+        public override IEnumerable<string> PlaybackOrigin()
+        {
+            return new[] { CuratedPlaylist.Id.ToString(), CuratedPlaylist.Title };
+        }
+
         public override bool ShowImage => true;
         public override string Image => CuratedPlaylist.Cover;
 

--- a/BMM.Core/ViewModels/FraKaareTeaserViewModel.cs
+++ b/BMM.Core/ViewModels/FraKaareTeaserViewModel.cs
@@ -58,7 +58,7 @@ namespace BMM.Core.ViewModels
             {
                 var randomEpisode = await Client.Podcast.GetRandomTrack(Podcast.Id);
 
-                await _mediaPlayer.Play(new List<IMediaTrack> {randomEpisode}, randomEpisode, GetType().Name);
+                await _mediaPlayer.Play(new List<IMediaTrack> {randomEpisode}, randomEpisode, PlaybackOriginString);
 
                 _analytics.LogEvent("Fra Kaare play random command was used");
             });
@@ -101,7 +101,7 @@ namespace BMM.Core.ViewModels
 
             foreach (var track in tracksToBePlayed)
             {
-                await _mediaPlayer.AddToEndOfQueue(track, GetType().Name);
+                await _mediaPlayer.AddToEndOfQueue(track, PlaybackOriginString);
             }
         }
 

--- a/BMM.Core/ViewModels/PlaybackHistoryViewModel.cs
+++ b/BMM.Core/ViewModels/PlaybackHistoryViewModel.cs
@@ -43,7 +43,7 @@ namespace BMM.Core.ViewModels
             if (!(item is IMediaTrack mediaTrack))
                 return;
 
-            await _mediaPlayer.Play(mediaTrack.EncloseInArray(), mediaTrack, GetType().Name, mediaTrack.LastPosition);
+            await _mediaPlayer.Play(mediaTrack.EncloseInArray(), mediaTrack, PlaybackOriginString, mediaTrack.LastPosition);
         }
 
         public override async Task Load()

--- a/BMM.Core/ViewModels/PodcastViewModel.cs
+++ b/BMM.Core/ViewModels/PodcastViewModel.cs
@@ -99,6 +99,11 @@ namespace BMM.Core.ViewModels
 
         public bool IsDownloaded => IsFollowing && !DownloadingFiles.Any();
 
+        public override IEnumerable<string> PlaybackOrigin()
+        {
+            return new[] { Podcast.Id.ToString(), Podcast.Title };
+        }
+
         public PodcastViewModel(
             IPodcastOfflineManager podcastDownloader,
             IConnection connection,


### PR DESCRIPTION
Right now we can't exactly know from which playlist a song was played. That makes it difficult to correctly assess the success of our playlists.
Therefore I now include the id and title of podcasts and playlists.