### PR TITLE
Video stops the audio playback fix

### DIFF
--- a/BMM.UI.Android/BMM.UI.Droid.csproj
+++ b/BMM.UI.Android/BMM.UI.Droid.csproj
@@ -48,7 +48,7 @@
     <AotAssemblies>false</AotAssemblies>
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidDexTool>d8</AndroidDexTool>
-    <AndroidSupportedAbis>x86_64</AndroidSupportedAbis>
+    <AndroidSupportedAbis>x86_64;x86;armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/BMM.UI.Android/Resources/layout/listitem_video_tile.xml
+++ b/BMM.UI.Android/Resources/layout/listitem_video_tile.xml
@@ -14,8 +14,8 @@
             android:layout_height="match_parent"
             android:orientation="vertical" >
 
-        <VideoView
-            android:id="@+id/VideoView"
+        <SurfaceView
+            android:id="@+id/VideoSurfaceView"
             android:layout_width="@dimen/match_constraint"
             android:layout_height="@dimen/match_constraint"
             local:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Previously to handle video playing I used VideoView. 
It automatically takes control over audio, which causes the main BMM player stop playing.

To avoid this situation, following method can be called:
`
_videoView.SetAudioFocusRequest(AudioFocus.None); `

The problem is, that method is available only for API >= 26.
Our app supports API >= 21, so I needed to find other solution.

As you can see in `openVideo() `method in VideoView class for older Android versions there is no way to override logic responsible for taking control over audio:

https://android.googlesource.com/platform/frameworks/base/+/768ca7d19bbd7ba73dee662480ea5a53ae3fbbe9/core/java/android/widget/VideoView.java#318

The only solution was to get rid of VideoView and implement SurfaceView and add MediaPlayer to it from code.
 