### PR TITLE
Unit tests potential fix

### DIFF
--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/AlbumViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/AlbumViewModelTests.cs
@@ -13,13 +13,6 @@ namespace BMM.Core.Test.Unit.ViewModels
     [TestFixture]
     public class AlbumViewModelTests : BaseViewModelTests
     {
-        [SetUp]
-        public void Init()
-        {
-            base.Setup();
-            base.AdditionalSetup();
-        }
-
         [Test]
         public async Task LoadItems_ShouldHandleNullValueAndDisplayEmptyDocument()
         {

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/AlbumsViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/AlbumsViewModelTests.cs
@@ -11,12 +11,9 @@ namespace BMM.Core.Test.Unit.ViewModels
     [TestFixture]
     public class AlbumsViewModelTests : BaseViewModelTests
     {
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            base.Setup();
-            base.AdditionalSetup();
-
+            base.SetUp();
             Client.Setup(x => x.Albums.GetPublishedByYear(It.IsAny<int>()))
                 .Returns(Task.FromResult<IList<Album>>(null));
         }

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/Base/BaseViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/Base/BaseViewModelTests.cs
@@ -4,12 +4,14 @@ using BMM.Core.Implementations.Analytics;
 using BMM.Core.Implementations.Exceptions;
 using BMM.Core.Implementations.Localization.Interfaces;
 using BMM.Core.NewMediaPlayer.Abstractions;
+using BMM.Core.Test.Helpers;
 using Moq;
 using MvvmCross.Base;
 using MvvmCross.Navigation;
 using MvvmCross.Localization;
 using MvvmCross.Plugin.Messenger;
 using MvvmCross.Tests;
+using MvvmCross.Views;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -17,6 +19,12 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
 {
     public class BaseViewModelTests : MvxIoCSupportingTest
     {
+        [SetUp]
+        public virtual void SetUp()
+        {
+            Setup();
+        }
+        
         protected override void AdditionalSetup()
         {
             Client = new Mock<IBMMClient>();
@@ -30,7 +38,10 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
             TextResource
                 .Setup(x => x[It.IsAny<string>()])
                 .Returns<string>(x => x);
-
+            
+            MockDispatcher = new MockDispatcher();
+            Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(MockDispatcher);
+            Ioc.RegisterSingleton<IMvxMainThreadAsyncDispatcher>(MockDispatcher);
             Ioc.RegisterSingleton(Client.Object);
             Ioc.RegisterSingleton(MediaQueue.Object);
             Ioc.RegisterSingleton(ExceptionHandler.Object);
@@ -56,5 +67,6 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
         protected Mock<IMvxMessenger> MvxMessenger { get; private set; }
 
         protected Mock<IMvxNavigationService> NavigationService { get; private set; }
+        protected MockDispatcher MockDispatcher { get; private set; }
     }
 }

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/Base/DocumentViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/Base/DocumentViewModelTests.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 
 namespace BMM.Core.Test.Unit.ViewModels.Base
 {
-    public class DocumentViewModelTests: IoCSupportingExceptionTest
+    public class DocumentViewModelTests : BaseViewModelTests
     {
         protected DocumentsViewModelImplementation DocumentsViewModel { get; set; }
         protected Mock<IBMMClient> Client { get; set; }
@@ -26,10 +26,7 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
             base.AdditionalSetup();
             Client = new Mock<IBMMClient>();
 
-            var mockDispatcher = new MockDispatcher();
             Ioc.RegisterSingleton(Client.Object);
-            Ioc.RegisterSingleton<IMvxMainThreadDispatcher>(mockDispatcher);
-            Ioc.RegisterSingleton<IMvxMainThreadAsyncDispatcher>(mockDispatcher);
             Ioc.RegisterSingleton(new Mock<INotificationCenter>(MockBehavior.Strict).Object);
             Ioc.RegisterSingleton(new Mock<IListenedTracksStorage>().Object);
             Ioc.RegisterSingleton(new Mock<IMediaQueue>().Object);
@@ -38,14 +35,12 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
 
             DocumentsViewModel = new DocumentsViewModelImplementation();
             DocumentsViewModel.PostprocessDocumentsAction = new Mock<IPostprocessDocumentsAction>().Object;
-            DocumentsViewModel.MvxMainThreadAsyncDispatcher = mockDispatcher;
+            DocumentsViewModel.MvxMainThreadAsyncDispatcher = MockDispatcher;
         }
 
         [Test]
         public void Reload_SetsIsRefreshingToTrue()
         {
-            base.Setup();
-
             Assert.False(DocumentsViewModel.IsRefreshing);
 
             DocumentsViewModel.LoadItemsAction = () =>
@@ -63,8 +58,6 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
         [Test]
         public void LoadItem_SetsIsLoadingToTrue()
         {
-            base.Setup();
-
             Assert.False(DocumentsViewModel.IsLoading);
 
             DocumentsViewModel.LoadItemsAction = () =>
@@ -82,7 +75,6 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
         public async Task LoadItem_ErrorEmitted_PassesExceptionToTheOutside()
         {
             // Arrange
-            Setup();
             DocumentsViewModel.LoadItemsAction = () => throw new NoInternetException();
 
             // Act & Assert
@@ -92,8 +84,6 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
         [Test]
         public async Task Reload_Completed_NotReloading()
         {
-            base.Setup();
-
             DocumentsViewModel.LoadItemsAction = () => new List<IDocumentPO>();
             await DocumentsViewModel.Refresh();
 
@@ -103,8 +93,6 @@ namespace BMM.Core.Test.Unit.ViewModels.Base
         [Test]
         public async Task LoadItem_Completed_NotLoading()
         {
-            base.Setup();
-
             DocumentsViewModel.LoadItemsAction = () => new List<IDocumentPO>();
             await DocumentsViewModel.Load();
 

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/ContributorViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/ContributorViewModelTests.cs
@@ -21,11 +21,9 @@ namespace BMM.Core.Test.Unit.ViewModels
         private IShuffleContributorAction _shuffleContributorActionMock;
         private ITrackPOFactory _trackPOFactoryMock;
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            base.Setup();
-            base.AdditionalSetup();
+            base.SetUp();
             Client.Setup(x => x.Contributors.GetById(It.IsAny<int>())).Returns(Task.FromResult(new Contributor() { Id = id, DocumentType = DocumentType.Contributor, Name = "Test" }));
             _shuffleContributorActionMock = Mock.Of<IShuffleContributorAction>();
             _trackPOFactoryMock = Mock.Of<ITrackPOFactory>();

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/ExploreContributorsViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/ExploreContributorsViewModelTests.cs
@@ -15,11 +15,9 @@ namespace BMM.Core.Test.Unit.ViewModels
     {
         private Mock<IContributorClient> _contributionClientMock;
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            Setup();
-            base.AdditionalSetup();
+            base.SetUp();
             _contributionClientMock = new Mock<IContributorClient>();
         }
         

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/MyContentFollowedPodcastsViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/MyContentFollowedPodcastsViewModelTests.cs
@@ -14,12 +14,9 @@ namespace BMM.Core.Test.Unit.ViewModels
     [TestFixture]
     public class MyContentFollowedPodcastsViewModelTests : BaseViewModelTests
     {
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            base.Setup();
-            base.AdditionalSetup();
-
+            base.SetUp();
             Client.Setup(x => x.Podcast.GetAll(CachePolicy.UseCacheAndRefreshOutdated))
                 .Returns(Task.FromResult<IList<Podcast>>(null));
         }

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/MyContentTrackCollectionsViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/MyContentTrackCollectionsViewModelTests.cs
@@ -18,12 +18,9 @@ namespace BMM.Core.Test.Unit.ViewModels
     {
         private readonly Mock<IConnection> _connectionMock = new Mock<IConnection>();
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            Setup();
-            base.AdditionalSetup();
-
+            base.SetUp();
             _connectionMock.Setup(x => x.GetStatus()).Returns(ConnectionStatus.Online);
         }
 

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/PlayerBaseViewModelUnitTest.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/PlayerBaseViewModelUnitTest.cs
@@ -18,12 +18,9 @@ namespace BMM.Core.Test.Unit.ViewModels
         private Mock<IMvxLanguageBinder> _mvxLanguageBinder = new Mock<IMvxLanguageBinder>();
         private Mock<IMediaPlayer> _mediaController = new Mock<IMediaPlayer>();
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            base.Setup();
-            base.AdditionalSetup();
-
+            base.SetUp();
             Client.Setup(x => x.Podcast.GetById(It.IsAny<int>(), It.IsAny<CachePolicy>()))
                 .Returns(Task.FromResult(new Podcast() {Cover = null, DocumentType = DocumentType.Podcast, Id = 1, Language = "en-US", Title = "Test"}));
             _mvxLanguageBinder.Setup(x => x.GetText(It.IsAny<string>())).Returns("test");

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/PodcastViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/PodcastViewModelTests.cs
@@ -19,6 +19,7 @@ using BMM.Core.Implementations.Podcasts;
 using BMM.Core.Implementations.TrackListenedObservation;
 using BMM.Core.Implementations.UI;
 using BMM.Core.NewMediaPlayer.Abstractions;
+using BMM.Core.Test.Unit.ViewModels.Base;
 using BMM.Core.ViewModels;
 using Moq;
 using MvvmCross.Base;
@@ -31,7 +32,7 @@ using NUnit.Framework;
 namespace BMM.Core.Test.Unit.ViewModels
 {
     [TestFixture]
-    public class PodcastViewModelTests : MvxIoCSupportingTest
+    public class PodcastViewModelTests : BaseViewModelTests
     {
         private Mock<IBMMClient> _client;
         private Mock<IExceptionHandler> _exceptionHandler;
@@ -49,9 +50,9 @@ namespace BMM.Core.Test.Unit.ViewModels
         private Mock<ITrackPOFactory> _trackPOFactory;
         private Mock<IDocumentsPOFactory> _documentsPOFactory;
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
+            base.SetUp();
             _client = new Mock<IBMMClient>();
             _exceptionHandler = new Mock<IExceptionHandler>();
             _podcastDownloader = new Mock<IPodcastOfflineManager>();
@@ -67,11 +68,6 @@ namespace BMM.Core.Test.Unit.ViewModels
             _shufflePodcastAction = new Mock<IShufflePodcastAction>();
             _trackPOFactory = new Mock<ITrackPOFactory>();
             _documentsPOFactory = new Mock<IDocumentsPOFactory>();
-            var _mainThreadDispatcher = new Mock<IMvxMainThreadDispatcher>();
-            var _mainThreadAsyncDispatcher = new Mock<IMvxMainThreadAsyncDispatcher>();
-
-            _mainThreadDispatcher.Setup(x => x.RequestMainThreadAction(It.IsAny<Action>(), It.IsAny<bool>())).Returns(true);
-            _mainThreadAsyncDispatcher.Setup(x => x.ExecuteOnMainThreadAsync(It.IsAny<Action>(), It.IsAny<bool>()));
             _client.Setup(x => x.Podcast.GetById(It.IsAny<int>(), It.IsAny<CachePolicy>()))
                 .ReturnsAsync(new Podcast() {Cover = "CoverStream", DocumentType = DocumentType.Podcast, Id = 1, Language = "en-US", Title = "Test"});
             _podcastDownloader.Setup(x => x.FollowPodcast(It.IsAny<Podcast>()));
@@ -80,8 +76,6 @@ namespace BMM.Core.Test.Unit.ViewModels
             _connection.Setup(x => x.GetStatus()).Returns(ConnectionStatus.Online);
             _languageBinder.Setup(x => x.GetText(It.IsAny<string>(), It.IsAny<object[]>())).Returns("test string");
 
-            Setup();
-            base.AdditionalSetup();
             var mockMvxMessenger = new Mock<IMvxMessenger>();
             Ioc.RegisterSingleton(_client.Object);
             Ioc.RegisterSingleton(_exceptionHandler.Object);
@@ -90,8 +84,6 @@ namespace BMM.Core.Test.Unit.ViewModels
             Ioc.RegisterSingleton(new Mock<INotificationCenter>(MockBehavior.Strict).Object);
             Ioc.RegisterSingleton(_inMemoryCache);
             Ioc.RegisterSingleton(_viewPresenter.Object);
-            Ioc.RegisterSingleton(_mainThreadDispatcher.Object);
-            Ioc.RegisterSingleton(_mainThreadAsyncDispatcher.Object);
             Ioc.RegisterSingleton(new Mock<IMediaQueue>().Object);
             Ioc.RegisterSingleton(new Mock<IMediaPlayer>().Object);
             Ioc.RegisterSingleton(new Mock<IMvxNavigationService>().Object);

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/PodcastsViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/PodcastsViewModelTests.cs
@@ -12,12 +12,9 @@ namespace BMM.Core.Test.Unit.ViewModels
     [TestFixture]
     public class PodcastsViewModelTests : BaseViewModelTests
     {
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            base.Setup();
-            base.AdditionalSetup();
-
+            base.SetUp();
             Client.Setup(x => x.Podcast.GetAll(CachePolicy.UseCacheAndRefreshOutdated))
                 .Returns(Task.FromResult<IList<Podcast>>(null));
         }

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/SettingsViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/SettingsViewModelTests.cs
@@ -59,12 +59,9 @@ namespace BMM.Core.Test.Unit.ViewModels
         private Mock<INotificationPermissionService> _notificationPermissionService;
         private Mock<IChangeNotificationSettingStateAction> _changeNotificationSettingStateAction;
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            base.Setup();
-            base.AdditionalSetup();
-
+            base.SetUp();
             _deviceInfo = new Mock<IDeviceInfo>();
 
             _userDialogs = new Mock<IUserDialogs>();

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/StorageManagerViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/StorageManagerViewModelTests.cs
@@ -18,11 +18,9 @@ namespace BMM.Core.Test.Unit.ViewModels
         private Mock<IStorageManager> _storageManager;
         private Mock<ISettingsStorage> _settingsStorage;
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            base.Setup();
-            base.AdditionalSetup();
+            base.SetUp();
             _storageManager = new Mock<IStorageManager>();
             _storageManager.Setup(x => x.Storages).Returns(new ObservableCollection<IFileStorage>(CreateFileStorages()));
 

--- a/BMM.Tests/BMM.Core.Test/Unit/ViewModels/TrackInfoViewModelTests.cs
+++ b/BMM.Tests/BMM.Core.Test/Unit/ViewModels/TrackInfoViewModelTests.cs
@@ -19,12 +19,9 @@ namespace BMM.Core.Test.Unit.ViewModels
         private Mock<IUriOpener> _uriOpenerMock;
         private Mock<IDeepLinkHandler> _deepLinkHandlerMock;
 
-        [SetUp]
-        public void Init()
+        public override void SetUp()
         {
-            Setup();
-            base.AdditionalSetup();
-
+            base.SetUp();
             TextResource.Setup(x => x.GetText(It.IsAny<string>())).Returns("Test");
         }
 


### PR DESCRIPTION
During unit tests on Azure Pipeline, we encounter random failures.
After investigating, I think it is related to race conditions when initializing the IoCProvider for MvvmCross for testing.
This PR  changes the initialization (SetUp) part of the View Model tessts and it seems to solve the problem.