### PR TITLE
Update deep links

### DIFF
--- a/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
+++ b/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
@@ -89,16 +89,16 @@ namespace BMM.Core.Implementations.DeepLinking
                 new RegexDeepLink($"^/{Music}$", NavigateTo<ExploreRecentMusicViewModel>),
                 new RegexDeepLink("^/contributors$", NavigateTo<ExploreContributorsViewModel>),
                 new RegexDeepLink("^/featured$", NavigateTo<CuratedPlaylistsViewModel>),
-                new RegexDeepLink("^/archive", NavigateTo<LibraryArchiveViewModel>),
-                new RegexDeepLink("^/year-in-review", NavigateTo<YearInReviewViewModel>),
+                new RegexDeepLink("^/archive$", NavigateTo<LibraryArchiveViewModel>),
+                new RegexDeepLink("^/year-in-review$", NavigateTo<YearInReviewViewModel>),
                 new RegexDeepLink<IdAndNameParameters>("^/playlist/curated/(?<id>[0-9]+)(/(?<name>.*))?$", OpenCuratedPlaylist),
                 new RegexDeepLink<IdAndNameParameters>("^/playlist/private/(?<id>[0-9]+)(/(?<name>.*))?$", OpenTrackCollection),
                 new RegexDeepLink<IdAndNameParameters>("^/playlist/podcast/(?<id>[0-9]+)(/(?<name>.*))?$", OpenPodcast),
-                new RegexDeepLink<SharingSecretParameters>("^/playlist/shared/(?<sharingsecret>.*)?$", OpenSharedTrackCollection ),
+                new RegexDeepLink<SharingSecretParameters>("^/playlist/shared/(?<sharingsecret>.*)$", OpenSharedTrackCollection ),
                 new RegexDeepLink<IdDeepLinkParameters>("^/playlist/contributor/(?<id>[0-9]+)(/(?<name>.*))?$", OpenContributor),
                 new RegexDeepLink<IdDeepLinkParameters>("^/album/(?<id>[0-9]+)$", OpenAlbum),
                 new TrackLinkParser("^/track/(?<id>[0-9]+)(/(?<language>.*))?$", PlayTrackById),
-                new RegexDeepLink<GenericDocumentsViewParameters>("^/browse/(?<path>.*)?$", OpenGenericDocumentsView),
+                new RegexDeepLink<GenericDocumentsViewParameters>("^/browse(/(?<path>.*))?$", OpenGenericDocumentsView),
                 new RegexDeepLink("^/$", DoNothing)
             };
         }


### PR DESCRIPTION
* Limit `archive` and `year-in-review`
* Always set `sharingsecret` in route for sharing playlists
* Optional slash on `browse` path