### PR TITLE
Feature/fix see all episodes

### DIFF
--- a/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
+++ b/BMM.Core/Implementations/DeepLinking/DeepLinkHandler.cs
@@ -13,6 +13,7 @@ using BMM.Api.Implementation.Constants;
 using BMM.Api.Implementation.Models;
 using BMM.Core.Constants;
 using BMM.Core.Helpers;
+using BMM.Core.Helpers.PresentationHints;
 using BMM.Core.Implementations.Analytics;
 using BMM.Core.Implementations.DeepLinking.Base.Interfaces;
 using BMM.Core.Implementations.DeepLinking.Parameters;
@@ -25,8 +26,10 @@ using BMM.Core.Translation;
 using BMM.Core.ViewModels;
 using BMM.Core.ViewModels.Parameters;
 using BMM.Core.ViewModels.Parameters.Interface;
+using IdentityModel.Client;
 using MvvmCross;
 using MvvmCross.Navigation;
+using MvvmCross.Presenters.Hints;
 using MvvmCross.ViewModels;
 
 namespace BMM.Core.Implementations.DeepLinking
@@ -123,7 +126,10 @@ namespace BMM.Core.Implementations.DeepLinking
         private async Task NavigateTo<T>() where T : IMvxViewModel
         {
             if (!_viewPresenter.IsViewModelShown<T>())
+            {
+                await _navigationService.ChangePresentation(new CloseFragmentsOverPlayerHint());
                 await _navigationService.Navigate<T>();
+            }
 
             SendEventIfNeeded(typeof(T));
         }
@@ -137,38 +143,40 @@ namespace BMM.Core.Implementations.DeepLinking
         private async Task NavigateTo<TVm, TParam>(TParam param) where TVm : IMvxViewModel<TParam>
         {
             if (!_viewPresenter.IsViewModelShown<TVm>())
+            {
+                await _navigationService.ChangePresentation(new CloseFragmentsOverPlayerHint());
                 await _navigationService.Navigate<TVm, TParam>(param);
+            }
         }
 
         private Task OpenSharedTrackCollection(SharingSecretParameters sharingSecretParameters)
         {
-            return _navigationService.Navigate<SharedTrackCollectionViewModel, ISharedTrackCollectionParameter>(
-                new SharedTrackCollectionParameter(sharingSecretParameters.SharingSecret));
+            return NavigateTo<SharedTrackCollectionViewModel, ISharedTrackCollectionParameter>(new SharedTrackCollectionParameter(sharingSecretParameters.SharingSecret));
         }
 
         private Task OpenAlbum(IdDeepLinkParameters idDeepLinksParameters)
         {
-            return _navigationService.Navigate<AlbumViewModel, int>(idDeepLinksParameters.Id);
+            return NavigateTo<AlbumViewModel, int>(idDeepLinksParameters.Id);
         }
 
         private Task OpenContributor(IdDeepLinkParameters idLinkParameters)
         {
-            return _navigationService.Navigate<ContributorViewModel, int>(idLinkParameters.Id);
+            return NavigateTo<ContributorViewModel, int>(idLinkParameters.Id);
         }
 
         private Task OpenPodcast(IdAndNameParameters deepLinkParameters)
         {
-            return _navigationService.Navigate<PodcastViewModel, Podcast>(new Podcast {Id = deepLinkParameters.Id, Title = deepLinkParameters.Name});
+            return NavigateTo<PodcastViewModel, Podcast>(new Podcast {Id = deepLinkParameters.Id, Title = deepLinkParameters.Name});
         }
 
         private Task OpenCuratedPlaylist(IdAndNameParameters deepLinkParameters)
         {
-            return _navigationService.Navigate<CuratedPlaylistViewModel, Playlist>(new Playlist {Id = deepLinkParameters.Id, Title = deepLinkParameters.Name});
+            return NavigateTo<CuratedPlaylistViewModel, Playlist>(new Playlist {Id = deepLinkParameters.Id, Title = deepLinkParameters.Name});
         }
 
         private Task OpenTrackCollection(IdAndNameParameters deepLinkParameters)
         {
-            return _navigationService.Navigate<TrackCollectionViewModel, ITrackCollectionParameter>(new TrackCollectionParameter(deepLinkParameters.Id, deepLinkParameters.Name));
+            return NavigateTo<TrackCollectionViewModel, ITrackCollectionParameter>(new TrackCollectionParameter(deepLinkParameters.Id, deepLinkParameters.Name));
         }
 
         private Task DoNothing()

--- a/BMM.Core/Models/POs/BibleStudy/BibleStudyExternalRelationPO.cs
+++ b/BMM.Core/Models/POs/BibleStudy/BibleStudyExternalRelationPO.cs
@@ -39,14 +39,14 @@ public class BibleStudyExternalRelationPO : BasePO, IBibleStudyExternalRelationP
         
         ClickedCommand = new ExceptionHandlingCommand(() =>
         {
-            if (_mediaPlayer.CurrentTrack?.Id == _trackId)
+            if (_trackId != null && _mediaPlayer.CurrentTrack?.Id == _trackId)
             {
                 _mediaPlayer.PlayPause();
                 return Task.CompletedTask;
             }
-            
+
             uriOpener.OpenUri(link);
-            return Task.CompletedTask;;
+            return Task.CompletedTask;
         });
         
         _trackId = deepLinkHandler.GetTrackIdToPlayIfPossible(link);

--- a/BMM.UI.Android/AndroidSetup.cs
+++ b/BMM.UI.Android/AndroidSetup.cs
@@ -179,7 +179,7 @@ namespace BMM.UI.Droid
             iocProvider.LazyConstructAndRegisterSingleton<IPlatformSpecificRemoteConfig, AndroidFirebaseRemoteConfig>();
             iocProvider.LazyConstructAndRegisterSingleton<IDeviceSupportVersionChecker, AndroidSupportVersionChecker>();
 
-            iocProvider.RegisterType<IUriOpener, UriOpener>();
+            iocProvider.RegisterDecorator<IUriOpener, InternalLinksOpener, UriOpener>();
             iocProvider.RegisterType<DownloadCompletedHandler, DownloadCompletedHandler>();
             iocProvider.RegisterType<MediaMountedHandler, MediaMountedHandler>();
 


### PR DESCRIPTION
The button "See all episodes", when clicking "More" on a podcast, is not working. (Only on Android)
Reproduction steps:
- open BMM
- Click More on podcast episode
- Click the button "See all episodes"
- -> instead of being taken to the podcast page, nothing happens.