### PR TITLE
15s jump on notification fix for Android >= API 33

### DIFF
--- a/BMM.UI.Android/Application/NewMediaPlayer/Notification/NowPlayingNotificationBuilder.cs
+++ b/BMM.UI.Android/Application/NewMediaPlayer/Notification/NowPlayingNotificationBuilder.cs
@@ -19,6 +19,8 @@ namespace BMM.UI.Droid.Application.NewMediaPlayer.Notification
     {
         public const string ActionSkipBackward = "org.brunstad.bmm.android.skipbackward";
         public const string ActionSkipForward = "org.brunstad.bmm.android.skipforward";
+        public const string JumpForwardTitle = "Jump forward";
+        public const string JumpBackwardTitle = "Jump back";
 
         private readonly Context _context;
         private readonly IMetadataMapper _metadataMapper;
@@ -45,8 +47,8 @@ namespace BMM.UI.Droid.Application.NewMediaPlayer.Notification
             _notificationManager = (NotificationManager)context.GetSystemService(Context.NotificationService);
 
             _skipToPreviousAction = new ExoPlayerAction(Resource.Drawable.icon_prev_notification, "Previous", PlaybackStateCompat.ActionSkipToPrevious);
-            _jumpBackwardAction = new CustomAction(Resource.Drawable.icon_skip_back_notification, "Jump back", ActionSkipBackward);
-            _jumpForwardAction = new CustomAction(Resource.Drawable.icon_skip_forward_notification, "Jump forward", ActionSkipForward);
+            _jumpBackwardAction = new CustomAction(Resource.Drawable.icon_skip_back_notification, JumpBackwardTitle, ActionSkipBackward);
+            _jumpForwardAction = new CustomAction(Resource.Drawable.icon_skip_forward_notification, JumpForwardTitle, ActionSkipForward);
             _playAction = new ExoPlayerAction(Resource.Drawable.icon_play_notification, "Play", PlaybackStateCompat.ActionPlay);
             _pauseAction = new ExoPlayerAction(Resource.Drawable.icon_pause_notification, "Pause", PlaybackStateCompat.ActionPause);
             //ToDo: when skipping a song it should be registered in PlayStatistics

--- a/BMM.UI.Android/Application/NewMediaPlayer/Notification/SkipBackwardActionProvider.cs
+++ b/BMM.UI.Android/Application/NewMediaPlayer/Notification/SkipBackwardActionProvider.cs
@@ -1,0 +1,25 @@
+using _Microsoft.Android.Resource.Designer;
+using Android.Support.V4.Media.Session;
+using BMM.Core.NewMediaPlayer.Abstractions;
+using Com.Google.Android.Exoplayer2;
+using Com.Google.Android.Exoplayer2.Ext.Mediasession;
+using MvvmCross;
+
+namespace BMM.UI.Droid.Application.NewMediaPlayer.Notification;
+
+public class SkipBackwardActionProvider : Java.Lang.Object, MediaSessionConnector.ICustomActionProvider
+{
+    public PlaybackStateCompat.CustomAction GetCustomAction(IPlayer player)
+    {
+        return new PlaybackStateCompat.CustomAction.Builder(
+            NowPlayingNotificationBuilder.ActionSkipBackward,
+            NowPlayingNotificationBuilder.JumpBackwardTitle,
+            ResourceConstant.Drawable.icon_skip_back_notification
+        ).Build();
+    }
+
+    public void OnCustomAction(IPlayer player, string action, Bundle extras)
+    {
+        Mvx.IoCProvider.Resolve<IMediaPlayer>().JumpBackward();
+    }
+}

--- a/BMM.UI.Android/Application/NewMediaPlayer/Notification/SkipForwardActionProvider.cs
+++ b/BMM.UI.Android/Application/NewMediaPlayer/Notification/SkipForwardActionProvider.cs
@@ -1,0 +1,25 @@
+using _Microsoft.Android.Resource.Designer;
+using Android.Support.V4.Media.Session;
+using BMM.Core.NewMediaPlayer.Abstractions;
+using Com.Google.Android.Exoplayer2;
+using Com.Google.Android.Exoplayer2.Ext.Mediasession;
+using MvvmCross;
+
+namespace BMM.UI.Droid.Application.NewMediaPlayer.Notification;
+
+public class SkipForwardActionProvider : Java.Lang.Object, MediaSessionConnector.ICustomActionProvider
+{
+    public PlaybackStateCompat.CustomAction GetCustomAction(IPlayer player)
+    {
+        return new PlaybackStateCompat.CustomAction.Builder(
+            NowPlayingNotificationBuilder.ActionSkipForward,
+            NowPlayingNotificationBuilder.JumpForwardTitle,
+            ResourceConstant.Drawable.icon_skip_forward_notification
+        ).Build();
+    }
+
+    public void OnCustomAction(IPlayer player, string action, Bundle extras)
+    {
+        Mvx.IoCProvider.Resolve<IMediaPlayer>().JumpForward();
+    }
+}

--- a/BMM.UI.Android/Application/NewMediaPlayer/Service/MusicService.cs
+++ b/BMM.UI.Android/Application/NewMediaPlayer/Service/MusicService.cs
@@ -185,11 +185,22 @@ namespace BMM.UI.Droid.Application.NewMediaPlayer.Service
             mediaSessionConnector.SetPlayer(ExoPlayer);
             mediaSessionConnector.SetPlaybackPreparer(preparer);
             mediaSessionConnector.SetQueueNavigator(new MetadataReadingQueueNavigator(_mediaSession, metadataMapper));
+            SetCustomActionsIfNeeded(mediaSessionConnector);
             //mediaSessionConnector.SetControlDispatcher(new IdleRecoveringControlDispatcher(_mediaSourceSetter));
             mediaSessionConnector.SetErrorMessageProvider(new CustomErrorMessageProvider(() => ExoPlayer,
                 Mvx.IoCProvider.Resolve<ISdkVersionHelper>(),
                 Mvx.IoCProvider.Resolve<ILogger>()));
             _mediaSourceSetter.CreateNew();
+        }
+
+        private static void SetCustomActionsIfNeeded(MediaSessionConnector mediaSessionConnector)
+        {
+            if (Build.VERSION.SdkInt < BuildVersionCodes.Tiramisu)
+                return;
+            
+            mediaSessionConnector.SetCustomActionProviders(
+                new SkipBackwardActionProvider(),
+                new SkipForwardActionProvider());
         }
 
         /// <summary>


### PR DESCRIPTION
Starting from Android API 33, media notification uses data from PlaybackState, and we can't control its behavior through NotificationBuilder anymore.
Therefore we needed to adjust MusicService to handle additional Custom Actions (15s jumps) and they are working again now. 