### PR TITLE
Image caching issue

### DIFF
--- a/BMM.UI.Android/Application/NewMediaPlayer/Notification/NowPlayingNotificationBuilder.cs
+++ b/BMM.UI.Android/Application/NewMediaPlayer/Notification/NowPlayingNotificationBuilder.cs
@@ -133,7 +133,23 @@ namespace BMM.UI.Droid.Application.NewMediaPlayer.Notification
                 .SetVisibility(NotificationCompat.VisibilityPublic);
 
             if (track?.ArtworkUri != null)
-                builder.SetLargeIcon((await ImageService.Instance.LoadUrl(track.ArtworkUri).AsBitmapDrawableAsync()).Bitmap);
+            {
+                try
+                {
+                    var image = await ImageService
+                        .Instance
+                        .LoadUrl(track.ArtworkUri)
+                        .AsBitmapDrawableAsync();
+                    
+                    image.SetIsDisplayed(true);
+                    builder.SetLargeIcon(image.Bitmap);
+                }
+                catch (Exception ex)
+                {
+                    //ignore
+                    Console.WriteLine(ex);
+                }
+            }
 
             return builder.Build();
         }

--- a/BMM.UI.iOS/Application/Implementations/IosSetup.cs
+++ b/BMM.UI.iOS/Application/Implementations/IosSetup.cs
@@ -145,6 +145,8 @@ namespace BMM.UI.iOS
             ImageService.Instance.Initialize(new Configuration
             {
                 InvalidateLayout = false,
+                HttpHeadersTimeout = 30,
+                HttpReadTimeout = 60,
                 HttpClient = new HttpClient(new AuthenticatedHttpImageClientHandler(Mvx.IoCProvider.Resolve<IMediaRequestHttpHeaders>())),
                 DiskCache = new SimpleDiskCache(Path.Combine(FileSystem.AppDataDirectory, ImageServiceConstants.ImageCacheFolder), new Configuration
                 {

--- a/BMM.UI.iOS/Application/Implementations/IosSetup.cs
+++ b/BMM.UI.iOS/Application/Implementations/IosSetup.cs
@@ -59,6 +59,8 @@ namespace BMM.UI.iOS
 {
     public class IosSetup : MvxIosSetup<App>
     {
+        private const int ImageServiceTimeoutInSeconds = 300;
+        
         protected override void InitializeFirstChance(IMvxIoCProvider iocProvider)
         {
             base.InitializeFirstChance(iocProvider);
@@ -145,9 +147,12 @@ namespace BMM.UI.iOS
             ImageService.Instance.Initialize(new Configuration
             {
                 InvalidateLayout = false,
-                HttpHeadersTimeout = 30,
-                HttpReadTimeout = 60,
-                HttpClient = new HttpClient(new AuthenticatedHttpImageClientHandler(Mvx.IoCProvider.Resolve<IMediaRequestHttpHeaders>())),
+                HttpHeadersTimeout = ImageServiceTimeoutInSeconds,
+                HttpReadTimeout = ImageServiceTimeoutInSeconds,
+                HttpClient = new HttpClient(new AuthenticatedHttpImageClientHandler(Mvx.IoCProvider.Resolve<IMediaRequestHttpHeaders>()))
+                {
+                    Timeout = TimeSpan.FromSeconds(ImageServiceTimeoutInSeconds),
+                },
                 DiskCache = new SimpleDiskCache(Path.Combine(FileSystem.AppDataDirectory, ImageServiceConstants.ImageCacheFolder), new Configuration
                 {
                     DiskCacheDuration = ImageServiceConstants.DiskCacheDuration


### PR DESCRIPTION
Problems with DownloadHeadersTimeoutException is now present only on iOS. 
The default value for HttpHeadersTimeout is 3 seconds.
There is unresolved bug on FFImageLoading library regading the DownloadHeadersTimeoutException error,  but the library is no longer maintananced. 
For Android we use increased timeout to 300 seconds and it seems to resolve the issue on that platform. 
I decided to reuse it also for iOS.